### PR TITLE
Make paths `msys2` friendly 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libdtrace-rs"
@@ -180,9 +180,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -190,18 +190,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a37c9326af5ed140c86a46655b5278de879853be5573c01df185b6f49a580a"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -262,9 +262,9 @@ checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "syn"
-version = "2.0.45"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eae3c679c56dc214320b67a1bc04ef3dfbd6411f6443974b5e4893231298e66"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
 name = "bindgen"
 version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +125,7 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 name = "libdtrace-rs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ name = "libdtrace_rs"
 path = "src/lib.rs"
 
 [build-dependencies]
+anyhow = "1.0.79"
 bindgen = "0.69.1"

--- a/build.rs
+++ b/build.rs
@@ -22,11 +22,7 @@ fn main() {
 
     build_dtrace();
     let outdir = std::path::Path::new(&env::var("OUT_DIR").unwrap()).join("dtrace.dll");
-    std::fs::copy(
-        get_dtrace_libpath().join("dtrace.dll"),
-        outdir,
-    )
-    .expect("Failed to copy dll");
+    std::fs::copy(get_dtrace_libpath().join("dtrace.dll"), outdir).expect("Failed to copy dll");
 
     let bindings = bindgen::Builder::default()
         .header("wrapper.h") // The input header
@@ -68,7 +64,7 @@ fn build_dtrace() {
         .output()
         .expect("Failed to clone dtrace");
 
-    Command::new("powershell")
+    let _ = Command::new("powershell")
         .args(&[".\\build-dtrace.ps1"])
         .output()
         .expect("failed to get external tools");

--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,15 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
+const DTRACE_SRC_DIR: &str = "_dtrace";
+
 // Set-ExecutionPolicy RemoteSigned –Scope Process
 // 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' opendtrace.sln /t:dtrace_dll:Rebuild /p:Configuration=Release /p:Platform=x64
 fn get_dtrace_libpath() -> PathBuf {
     let dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    std::path::Path::new(&dir).join("target\\dtrace\\build\\x64\\Release\\lib\\")
+    std::path::Path::new(&dir)
+        .join(DTRACE_SRC_DIR)
+        .join("dtrace/build/x64/Release/lib")
 }
 
 fn main() {
@@ -20,7 +24,10 @@ fn main() {
         get_dtrace_libpath().display()
     );
 
-    build_dtrace();
+    print!("Trying to buidld dtrace library... ");
+    build_dtrace().unwrap();
+    println!("\t....[DONE]");
+
     let outdir = std::path::Path::new(&env::var("OUT_DIR").unwrap()).join("dtrace.dll");
     std::fs::copy(get_dtrace_libpath().join("dtrace.dll"), outdir).expect("Failed to copy dll");
 
@@ -54,18 +61,33 @@ fn main() {
         .expect("Couldn't write bindings!");
 }
 
-fn build_dtrace() {
-    Command::new("git")
-        .args(&[
-            "clone",
-            "https://github.com/microsoft/DTrace-on-Windows.git",
-            "target\\dtrace",
-        ])
-        .output()
-        .expect("Failed to clone dtrace");
+fn build_dtrace() -> anyhow::Result<()> {
+    let output = if !PathBuf::from(DTRACE_SRC_DIR).is_dir() {
+        Command::new("git")
+            .args(&[
+                "clone",
+                "https://github.com/microsoft/DTrace-on-Windows.git",
+                DTRACE_SRC_DIR,
+            ])
+            .output()
+            .expect("Failed to clone dtrace");
+    } else {
+        Command::new("git")
+            .arg("udpate")
+            .current_dir(DTRACE_SRC_DIR)
+            .output()
+            .expect("Failed to update dtrace");
+    };
 
-    let _ = Command::new("powershell")
-        .args(&[".\\build-dtrace.ps1"])
+    println!("> git update/clone {output:?}");
+
+    let output = Command::new("powershell.exe")
+        .arg("-F")
+        .arg("./build-dtrace.ps1")
         .output()
         .expect("failed to get external tools");
+
+    println!("> git clone {output:?}");
+
+    Ok(())
 }


### PR DESCRIPTION
With current paths, the build will fail in msys2 terminal on Windows. This PR changes the paths. 